### PR TITLE
Custom http request executor with async support

### DIFF
--- a/paypalhttp/http_client.py
+++ b/paypalhttp/http_client.py
@@ -12,7 +12,7 @@ class HttpClient(object):
     def __init__(self, environment):
         self._injectors = []
         self.environment = environment
-        self.request_executor = requests.request
+        self.req_executor = requests.request
         self.encoder = Encoder([Json(), Text(), Multipart(), FormEncoded()])
 
     def __getattr__(self, attribute):
@@ -20,8 +20,7 @@ class HttpClient(object):
             if asyncio.iscoroutinefunction(self.req_executor):
                 return self.execute_async
             return self.execute_sync
-
-        return super().__getattr__(attribute)
+        raise AttributeError()
 
     async def execute_async(self, request):
         response = await self.req_executor(**self.prepare(request))


### PR DESCRIPTION
This adds a property that can be overriden to specify an async executor,
as with httpx or a custom "request-like" method invoking aiohttp or any
other async http client.

Mantains API and will not break current installations, if this library
should work with the (defunct, not supported and past-EOL) or with
python versions prior to 3.5, this PR would require a few small tweaks:

- Using generator-based coroutines (altough is currently being
  deprecated by python and won't be supported on 3.10).
- Added an IF upon asyncio import

Note: I've not added any tests because I'm unsure about adding an async http library as a dependency.