### PR TITLE
Set encoding to UTF-8 when no encoding is specified

### DIFF
--- a/paypalhttp/http_client.py
+++ b/paypalhttp/http_client.py
@@ -69,6 +69,7 @@ class HttpClient(object):
         return raw_headers
 
     def parse_response(self, response):
+        response.encoding = response.encoding or 'utf-8'
         status_code = response.status_code
 
         if 200 <= status_code <= 299:

--- a/paypalhttp/testutils/testharness.py
+++ b/paypalhttp/testutils/testharness.py
@@ -15,7 +15,7 @@ class TestHarness(unittest.TestCase):
     def stub_request_with_response(self, request, response_body="", status=200, content_type="application/json"):
         body = None
         if response_body:
-            if isinstance(response_body, str):
+            if isinstance(response_body, (bytes, str)):
                 body = response_body
             else:
                 body = json.dumps(response_body)

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -202,5 +202,18 @@ class HttpClientTest(TestHarness):
 
         license.close()
 
+    @responses.activate
+    def test_HttpClient_encoding(self):
+        client = HttpClient(self.environment())
+
+        request = GenericRequest()
+        request.path = "/error"
+        request.verb = "GET"
+        self.stub_request_with_response(
+            request, status=200, response_body=u'{"city": "D\u00fcsseldorf"}'.encode('utf-8'))
+
+        resp = client.execute(request)
+        self.assertEqual(resp.result.city, 'D\u00fcsseldorf')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
PayPal's actual responses just say `Content-Type: application/json`, causing requests to guess the encoding. This is wrong; the data from PayPal is always UTF-8.
Therefore, default to UTF-8 when no encoding is set.

Demonstration of the problem:

```

import paypalhttp

class PseudoRequest:
    verb = 'GET'
    path = '/2020/paypal.json'
    headers = {'Content-Type': 'application/json'}
    body = None

class PseudoEnvironment:
    base_url = 'https://phihag.de'

environment = PseudoEnvironment()
client = paypalhttp.HttpClient(environment)
res = client.execute(PseudoRequest())
s = res.result.payer.address.admin_area_1

assert 'ü' in s, s
```
