### PR TITLE
sometimes paypal returns "application/JSON" as content-type

### DIFF
--- a/paypalhttp/encoder.py
+++ b/paypalhttp/encoder.py
@@ -9,7 +9,7 @@ class Encoder(object):
     def serialize_request(self, httprequest):
         if hasattr(httprequest, "headers"):
             if "content-type" in httprequest.headers:
-                contenttype = httprequest.headers["content-type"]
+                contenttype = httprequest.headers["content-type"].lower()
                 enc = self._encoder(contenttype)
                 if enc:
                     return enc.encode(httprequest)
@@ -25,7 +25,7 @@ class Encoder(object):
 
     def deserialize_response(self, response_body, headers):
         if headers and "content-type" in headers:
-            contenttype = headers["content-type"]
+            contenttype = headers["content-type"].lower()
             enc = self._encoder(contenttype)
             if enc:
                 return enc.decode(response_body)


### PR DESCRIPTION
Sometimes paypal returns "application/JSON" as content-type instead of "application/json".
In that case, call to API returns following error:
```
Unable to deserialize response with content-type application/JSON. Supported decodings are ['application/json', 'text/.*', 'multipart/.*', 'application/x-www-form-urlencoded']
```
while api call was successfull

As example, it was happening at 2021-04-18 17:44:38 GMT for more than 24 hours.
