### PR TITLE
Hdl 285 paypal sdk header: Fixing Case Sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 1.0.1
+* Fix Case Sensitivity of Content Type for deserialization process
+
 ## 1.0.0
 * First Release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2019 PayPal, Inc.
+Copyright (c) 2009-2021 PayPal, Inc.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/paypalhttp/encoder.py
+++ b/paypalhttp/encoder.py
@@ -25,7 +25,7 @@ class Encoder(object):
 
     def deserialize_response(self, response_body, headers):
         if headers and "content-type" in headers:
-            contenttype = headers["content-type"]
+            contenttype = headers["content-type"].lower()
             enc = self._encoder(contenttype)
             if enc:
                 return enc.decode(response_body)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = "1.0.0"
+version = "1.0.1"
 
 long_description = """
 	PayPalHttp is a generic http client designed to be used with code-generated projects.

--- a/tests/encoder_test.py
+++ b/tests/encoder_test.py
@@ -161,10 +161,28 @@ class EncoderTest(unittest.TestCase):
 
         self.assertEqual(j, b)
 
+    def test_Encoder_deserialize_response_text_case_insensitive(self):
+        j = 'some plain text'
+        headers = {"content-type": "TEXT/plain"}
+
+        b = Encoder([Json(), Text(), Multipart(), FormEncoded()]).deserialize_response(j, headers)
+
+        self.assertEqual(j, b)
+
     def test_Encoder_deserialize_response_Json(self):
         j = '{"key": "value", "list": ["one", "two"]}'
 
         headers = {"content-type": "application/json"}
+
+        b = Encoder([Json(), Text(), Multipart(), FormEncoded()]).deserialize_response(j, headers)
+
+        self.assertEqual("value", b["key"])
+        self.assertEqual(["one", "two"], b["list"])
+
+    def test_Encoder_deserialize_response_Json_case_insensitive(self):
+        j = '{"key": "value", "list": ["one", "two"]}'
+
+        headers = {"content-type": "application/JSON"}
 
         b = Encoder([Json(), Text(), Multipart(), FormEncoded()]).deserialize_response(j, headers)
 


### PR DESCRIPTION
Internal Change for Ticket 285: 

Author: hlahlou

Changes made in Encoder and HttpClient to force the value for Content-Type to lowercase.

Added Unit Tests to ensure that deserialization and execution of HTTP request were case insensitive and could handle Content-Types of different casing (ex: application/json vs application/JSON)

Also updated the license, change log, and version to reflect changes made and to update copyright.


Results of Unit Tests:
<img width="1792" alt="Screen Shot 2021-08-25 at 1 13 10 PM" src="https://user-images.githubusercontent.com/30755392/130838872-42987d70-2ef8-415c-aa6f-b343adf67a9f.png">

Integration Test Results with Checkout SDK:
<img width="1792" alt="Screen Shot 2021-08-30 at 3 01 51 PM" src="https://user-images.githubusercontent.com/30755392/131736645-65bfe060-699c-445b-a002-87ae762c05cc.png">
