### PR TITLE
Add support for replaceable HTTP backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ client.add_injector(lambda req: print req)
 ...
 ```
 
+### Backends
+
+If you need even more control over the request, for example to route the request through custom proxying or rewriting logic, you can provide your own backend to `HttpClient` by implementing `paypalhttp.http_backends.AbstractBackend` and passing an instance of that implementation as the second argument (`backend=`) to the constructor of `HttpClient`.
+
+The backend must implement one method, `#request`, accepting the following arguments:
+
+* `method`: _(Text)_ The HTTP request method
+* `url`: _(Text)_ The full URL that will be requested, including the prefix.
+* `headers`: _(Dict[Text, Text])_ Headers to be set on the request.
+* `data`: _(RequestsBody)_ The body of the request, for methods that support it. `RequestsBody` is defined as any one of the following:
+  * `None`
+  * `AnyStr` (`str` or `bytes` in Python 3; `str` or `unicode` in Python 2)
+  * `Dict[Text, Any]` (`Text` is `str` in Python 3 and `unicode` in Python 2)
+  * `Iterable[Tuple[Text, Any]]`
+
+If an exception is not thrown, `#request` must return a `paypalhttp.http_backends.Response`, which is a `NamedTuple` with the following fields (all are required):
+
+* `status_code`: `int`
+* `text`: `Text`
+* `headers`: `Dict[Text, Text]`
+
+The included backend, `RequestsBackend`, relies on `requests`. While `requests` is listed in `requirements.txt`, it is not in fact required if you will always pass your own backend to `HttpClient`.
+
 ### Error Handling
 
 `HttpClient#execute` may raise an `IOError` if something went wrong during the course of execution. If the server returned a non-200 response, this execption will be an instance of [`HttpError`](paypalhttp/http_error.py) that will contain a status code and headers you can use for debugging. 

--- a/paypalhttp/http_backends.py
+++ b/paypalhttp/http_backends.py
@@ -1,0 +1,70 @@
+from collections import namedtuple
+from typing import Any, NamedTuple, TYPE_CHECKING, Dict, Text
+
+if TYPE_CHECKING:
+    from typing import AnyStr, Iterable, Optional, Tuple, Union
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+"""
+Local replacement for requests.Response.
+"""
+Response = NamedTuple(
+    "Response",
+    [
+        ('status_code', int),
+        ('text', Text),
+        ('headers', Dict[Text, Text]),
+    ]
+)
+
+class AbstractBackend:
+    """
+    Function prototype for HTTP backends to perform requests.
+    """
+    def request(
+        self,
+        method,  # type: Text
+        url,  # type: Text
+        headers,  # type: Dict[Text, Text]
+        data=None  # type: Optional[Union[AnyStr, Dict[Text, Any], Iterable[Tuple[Text, Any]]]]
+    ):  # type: (...) -> Response
+        raise NotImplementedError()
+
+
+class RequestsBackend(AbstractBackend):
+    def __init__(self, session=None):  # type: (Optional[requests.Session]) -> None
+        if requests is None:
+            raise RuntimeError(
+                "requests is not available in your Python environment. Please install it "
+                "using pip or your distribution's package manager."
+            )
+
+        if session is None:
+            session = requests.Session()
+
+        self.session = session
+
+    def request(
+        self,
+        method,  # type: Text
+        url,  # type: Text
+        headers,  # type: Dict[Text, Text]
+        data=None  # type: Optional[Union[AnyStr, Dict[Text, Any], Iterable[Tuple[Text, Any]]]]
+    ):  # type: (...) -> Response
+        resp = self.session.request(
+            method=method,
+            url=url,
+            headers=headers,
+            data=data
+        )
+
+        return Response(
+            status_code=resp.status_code,
+            text=resp.text,
+            headers=resp.headers
+        )

--- a/paypalhttp/testutils/__init__.py
+++ b/paypalhttp/testutils/__init__.py
@@ -1,1 +1,2 @@
+from paypalhttp.testutils.mock_backend import MockBackend
 from paypalhttp.testutils.testharness import TestHarness

--- a/paypalhttp/testutils/mock_backend.py
+++ b/paypalhttp/testutils/mock_backend.py
@@ -1,0 +1,24 @@
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, AnyStr, Dict, Iterable, Optional, Text, Tuple, Union
+
+from paypalhttp.http_backends import AbstractBackend, Response
+
+class MockBackend(AbstractBackend):
+    def request(
+        self,
+        method,  # type: Text
+        url,  # type: Text
+        headers,  # type: Dict[Text, Text]
+        data=None  # type: Optional[Union[AnyStr, Dict[Text, Any], Iterable[Tuple[Text, Any]]]]
+    ):  # type: (...) -> Response
+        return Response(
+            status_code=200,
+            text=json.dumps({'url': url, 'method': method}),
+            headers={
+                'server': 'MockBackend/1.0',
+                'content-type': 'application/json',
+            }
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mock==2.0.0
 requests==2.18.0
 responses==0.5.1
+typing==3.10.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=version,
     author="PayPal",
     packages=["paypalhttp", "paypalhttp/testutils", "paypalhttp/serializers"],
-    install_requires=['requests>=2.0.0', 'six>=1.0.0', 'pyopenssl>=0.15'],
+    install_requires=['requests>=2.0.0', 'six>=1.0.0', 'pyopenssl>=0.15', 'typing>=3.10.0.0'],
     license="MIT",
     classifiers=[
         'Intended Audience :: Developers',
@@ -20,7 +20,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -2,8 +2,7 @@ import unittest
 import responses
 
 from paypalhttp import HttpClient, File
-from paypalhttp.testutils import TestHarness
-
+from paypalhttp.testutils import MockBackend, TestHarness
 
 class GenericRequest:
 
@@ -179,6 +178,21 @@ class HttpClientTest(TestHarness):
         client.execute(request)
 
         self.assertEqual(len(request.headers), 0)
+
+    def test_HttpClient_backendIsCalled(self):
+        client = HttpClient(self.environment(), MockBackend())
+
+        self.assertTrue(isinstance(client.backend, MockBackend))
+
+        request = GenericRequest()
+        request.path = "/"
+        request.verb = "GET"
+
+        response = client.execute(request)
+
+        # Verify that the HttpClient correct calls out to the backend provided
+        # to the constructor.
+        self.assertEqual(response.headers['server'], 'MockBackend/1.0')
 
     @responses.activate
     def test_HttpClient_execute_filesArePreservedInCopy(self):

--- a/tests/http_response_test.py
+++ b/tests/http_response_test.py
@@ -141,7 +141,7 @@ class HttpResponseTest(unittest.TestCase):
         resp = HttpResponse(obj, 200)
 
         self.assertTrue('int' in resp.result)
-    
+
     def testHttpResponse_listResultSuportsInOperator(self):
         obj = ['one', 'two', 'three']
 


### PR DESCRIPTION
Instead of tightly coupling to requests, allow the HTTP backend to be replaced with a custom implementation. Provide an abstract class and a default implementation that uses requests the same as it's used now.

Unit tests are included and have been run successfully on Python 2.7 and 3.10 locally.

The new functionality is documented in `README.md`, and mypy type annotations are included on new code.

**Compatibility note:** This change retains backward compatibility to Python 2.7 and deprecates Python 2.6 compatibility. Python 2.6 reached EOL on August 24, 2010, nearly 12 years ago, so I believe this change is safe to make.

**Legal:** This contribution was made in the course of my employment with Dropbox, Inc., which has authorized the release of this code under the MIT License. This code is offered without any warranty; see the terms of the MIT License in the `LICENSE` file for details. This license release is valid only if this commit passes PGP signature validation using the public key on the author's GitHub account.

Signed-Off-By: Dan Fuhry <fuhry@dropbox.com>